### PR TITLE
Add HouseRules infrastructure for optional rule settings

### DIFF
--- a/WerewolfGame/Models/GameManager.swift
+++ b/WerewolfGame/Models/GameManager.swift
@@ -7,12 +7,14 @@ class GameManager {
     var lastExecutedName: String? = nil
     var victoryTeam: Team? = nil
     let debugMode: Bool
+    let houseRules: HouseRules
 
-    init(playerNames: [String], debugMode: Bool = false) {
+    init(playerNames: [String], debugMode: Bool = false, houseRules: HouseRules = HouseRules()) {
         self.players = playerNames.enumerated().map { index, name in
             Player(id: index, name: name)
         }
         self.debugMode = debugMode
+        self.houseRules = houseRules
     }
 
     // MARK: - 役職割り当て

--- a/WerewolfGame/Models/GameSettings.swift
+++ b/WerewolfGame/Models/GameSettings.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+struct HouseRules: Codable, Equatable {
+    // 個別ルールは後続Issueで追加。ここでは空の構造体を用意。
+}
+
 enum GameSettings {
     static let defaultRoleCounts: [RoleType: Int] = [
         .werewolf: 2,

--- a/WerewolfGame/ViewModels/GameViewModel.swift
+++ b/WerewolfGame/ViewModels/GameViewModel.swift
@@ -13,6 +13,7 @@ class GameViewModel {
     var playerNames: [String] = []
     var roleCounts: [RoleType: Int] = GameSettings.defaultRoleCounts
     var debugMode: Bool = false
+    var houseRules = HouseRules()
     var errorMessage: String = ""
 
     // MARK: - ゲーム状態
@@ -99,7 +100,7 @@ class GameViewModel {
             roles.append(contentsOf: Array(repeating: role, count: count))
         }
 
-        let gm = GameManager(playerNames: playerNames, debugMode: debugMode)
+        let gm = GameManager(playerNames: playerNames, debugMode: debugMode, houseRules: houseRules)
         gm.assignRoles(roles)
         gameManager = gm
 
@@ -217,6 +218,7 @@ class GameViewModel {
         playerNames = []
         roleCounts = GameSettings.defaultRoleCounts
         debugMode = false
+        houseRules = HouseRules()
         errorMessage = ""
         gameManager = nil
         currentPlayerIndex = 0

--- a/WerewolfGameTests/GameManagerTests.swift
+++ b/WerewolfGameTests/GameManagerTests.swift
@@ -7,8 +7,8 @@ final class GameManagerTests: XCTestCase {
 
     // MARK: - ヘルパー
 
-    private func makeGM(_ names: [String]? = nil) -> GameManager {
-        GameManager(playerNames: names ?? playerNames)
+    private func makeGM(_ names: [String]? = nil, houseRules: HouseRules = HouseRules()) -> GameManager {
+        GameManager(playerNames: names ?? playerNames, houseRules: houseRules)
     }
 
     private func assignFixedRoles(_ gm: GameManager, roles: [(String, RoleType)]) {
@@ -19,9 +19,9 @@ final class GameManagerTests: XCTestCase {
         }
     }
 
-    private func makeGMWithRoles(_ roles: [(String, RoleType)]) -> GameManager {
+    private func makeGMWithRoles(_ roles: [(String, RoleType)], houseRules: HouseRules = HouseRules()) -> GameManager {
         let names = roles.map { $0.0 }
-        let gm = GameManager(playerNames: names)
+        let gm = GameManager(playerNames: names, houseRules: houseRules)
         for (i, (_, role)) in roles.enumerated() {
             gm.players[i].role = role
         }
@@ -29,6 +29,12 @@ final class GameManagerTests: XCTestCase {
     }
 
     // MARK: - 初期化テスト
+
+    func testInitWithHouseRules() {
+        let rules = HouseRules()
+        let gm = makeGM(houseRules: rules)
+        XCTAssertEqual(gm.houseRules, rules)
+    }
 
     func testInitialization() {
         let gm = makeGM()


### PR DESCRIPTION
## Summary
- `HouseRules` 構造体（`Codable`, `Equatable`）を `GameSettings.swift` に新設。個別ルールは後続 Issue で追加予定
- `GameManager.init` に `houseRules` パラメータを追加（デフォルト値付きで既存コードへの影響なし）
- `GameViewModel` で `houseRules` を保持し、`startGame()` で `GameManager` に受け渡し、`resetGame()` でリセット
- テストヘルパー `makeGM()` / `makeGMWithRoles()` に `houseRules` パラメータを追加 & `testInitWithHouseRules` テストを追加

## Test plan
- [x] `xcodebuild build` 成功
- [x] `xcodebuild test` 全43テスト通過（新規1テスト含む）

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)