### PR TITLE
Fix compiler warnings: unused variable and Concurrency violations

### DIFF
--- a/WerewolfGame/ViewModels/GameViewModel.swift
+++ b/WerewolfGame/ViewModels/GameViewModel.swift
@@ -201,7 +201,7 @@ class GameViewModel {
     }
 
     func proceedToNight() {
-        guard let gm = gameManager else { return }
+        guard gameManager != nil else { return }
         stage = .nightPhase
         currentPlayerIndex = 0
         nightActions = [:]


### PR DESCRIPTION
## Summary
- Fixed unused variable `gm` warning in `GameViewModel.proceedToNight()` by replacing `guard let gm = gameManager` with `guard gameManager != nil`
- Fixed 3 Swift Concurrency actor isolation warnings in `DiscussionTimerView` by replacing `Timer.scheduledTimer` (Sendable closure) with an async `Task`-based timer that naturally runs on the MainActor

Closes #15

## Test plan
- [x] Build succeeds with zero warnings
- [x] All 44 tests pass
- [ ] Verify discussion timer starts, pauses, resets correctly in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)